### PR TITLE
Add model selector to support multiple APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,38 @@ This repository contains a powerful coding assistant application that integrates
 
 > **Note**: This is an experimental project developed by Skirano to test the new DeepSeek v3 API capabilities. It was developed as a rapid prototype and should be used accordingly.
 
+## Model Selector and API Configuration
+
+The application now supports selecting different models and configuring their respective APIs, including DeepSeek, OpenAI, local OpenAI compatible endpoints, and Mistral.
+
+### How to Use the Model Selector
+
+1. When you run the script (`python3 main.py`), you will be prompted to select a model:
+   - 1. DeepSeek
+   - 2. OpenAI
+   - 3. Local OpenAI Compatible Endpoint
+   - 4. Mistral
+
+2. Enter the number corresponding to your choice.
+
+3. The application will configure the client with the appropriate API key and base URL based on your selection.
+
+### Configuring Different APIs
+
+1. **DeepSeek**
+   - Ensure you have the `DEEPSEEK_API_KEY` set in your `.env` file.
+   - The base URL for DeepSeek is pre-configured as `https://api.deepseek.com`.
+
+2. **OpenAI**
+   - Ensure you have the `OPENAI_API_KEY` set in your `.env` file.
+   - The base URL for OpenAI is pre-configured as `https://api.openai.com`.
+
+3. **Local OpenAI Compatible Endpoint**
+   - Ensure you have the `LOCAL_OPENAI_API_KEY` and `LOCAL_OPENAI_BASE_URL` set in your `.env` file.
+   - The base URL should point to your local OpenAI compatible endpoint.
+
+4. **Mistral**
+   - Ensure you have the `MISTRAL_API_KEY` set in your `.env` file.
+   - The base URL for Mistral is pre-configured as `https://api.mistral.com`.
+
+By following these steps, you can easily switch between different APIs and leverage the capabilities of each within the same application.

--- a/main.py
+++ b/main.py
@@ -21,10 +21,49 @@ console = Console()
 # 1. Configure OpenAI client and load environment variables
 # --------------------------------------------------------------------------------
 load_dotenv()  # Load environment variables from .env file
+
+def select_model():
+    """Prompt the user to select a model and return the corresponding API key and base URL."""
+    console.print("Select a model:")
+    console.print("1. DeepSeek")
+    console.print("2. OpenAI")
+    console.print("3. Local OpenAI Compatible Endpoint")
+    console.print("4. Mistral")
+    
+    choice = console.input("Enter the number of your choice: ").strip()
+    
+    if choice == "1":
+        return {
+            "api_key": os.getenv("DEEPSEEK_API_KEY"),
+            "base_url": "https://api.deepseek.com"
+        }
+    elif choice == "2":
+        return {
+            "api_key": os.getenv("OPENAI_API_KEY"),
+            "base_url": "https://api.openai.com"
+        }
+    elif choice == "3":
+        return {
+            "api_key": os.getenv("LOCAL_OPENAI_API_KEY"),
+            "base_url": os.getenv("LOCAL_OPENAI_BASE_URL")
+        }
+    elif choice == "4":
+        return {
+            "api_key": os.getenv("MISTRAL_API_KEY"),
+            "base_url": "https://api.mistral.com"
+        }
+    else:
+        console.print("[red]Invalid choice. Defaulting to DeepSeek.[/red]")
+        return {
+            "api_key": os.getenv("DEEPSEEK_API_KEY"),
+            "base_url": "https://api.deepseek.com"
+        }
+
+model_config = select_model()
 client = OpenAI(
-    api_key=os.getenv("DEEPSEEK_API_KEY"),
-    base_url="https://api.deepseek.com"
-)  # Configure for DeepSeek API
+    api_key=model_config["api_key"],
+    base_url=model_config["base_url"]
+)
 
 # --------------------------------------------------------------------------------
 # 2. Define our schema using Pydantic for type safety
@@ -107,6 +146,8 @@ system_PROMPT = dedent("""\
     7. Suggest tests or validation steps when appropriate
 
     Remember: You're a senior engineer - be thorough, precise, and thoughtful in your solutions.
+
+    Note: You can use different APIs including DeepSeek, OpenAI, and local OpenAI compatible endpoints.
 """)
 
 # --------------------------------------------------------------------------------


### PR DESCRIPTION
Add a model selector to allow switching between DeepSeek and other APIs, including local OpenAI compatible endpoints.

* **main.py**:
  - Add a function `select_model` to prompt the user to select a model and return the corresponding API key and base URL.
  - Update the `client` initialization to use the selected model's API key and base URL.
  - Modify the system prompt to include instructions for using different APIs.
  - Add options for DeepSeek, Mistral, OpenAI, and a local option.

* **README.md**:
  - Add documentation explaining how to use the model selector and configure different APIs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nutspiano/deepseek-engineer/pull/1?shareId=8fd2bf74-c5cf-4d3b-814c-57243c56b441).